### PR TITLE
Added relative orbit velocity readout to Rendezvous category

### DIFF
--- a/KerbalEngineer/Flight/Readouts/ReadoutLibrary.cs
+++ b/KerbalEngineer/Flight/Readouts/ReadoutLibrary.cs
@@ -19,17 +19,15 @@
 
 #region Using Directives
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 using KerbalEngineer.Flight.Readouts.Miscellaneous;
 using KerbalEngineer.Flight.Readouts.Orbital;
 using KerbalEngineer.Flight.Readouts.Rendezvous;
 using KerbalEngineer.Flight.Readouts.Surface;
 using KerbalEngineer.Flight.Readouts.Vessel;
 using KerbalEngineer.Settings;
-
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using AltitudeSeaLevel = KerbalEngineer.Flight.Readouts.Surface.AltitudeSeaLevel;
 using ApoapsisHeight = KerbalEngineer.Flight.Readouts.Orbital.ApoapsisHeight;
 using OrbitalPeriod = KerbalEngineer.Flight.Readouts.Orbital.OrbitalPeriod;
@@ -125,6 +123,7 @@ namespace KerbalEngineer.Flight.Readouts
                 readouts.Add(new PhaseAngle());
                 readouts.Add(new InterceptAngle());
                 readouts.Add(new RelativeInclination());
+                readouts.Add(new RelativeVelocity());
                 readouts.Add(new TimeToRelativeAscendingNode());
                 readouts.Add(new TimeToRelativeDescendingNode());
                 readouts.Add(new AngleToRelativeAscendingNode());

--- a/KerbalEngineer/Flight/Readouts/Rendezvous/RelativeVelocity.cs
+++ b/KerbalEngineer/Flight/Readouts/Rendezvous/RelativeVelocity.cs
@@ -1,0 +1,64 @@
+﻿// 
+//     Kerbal Engineer Redux
+// 
+//     Copyright (C) 2014 CYBUTEK
+// 
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+// 
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+// 
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// 
+
+#region Using Directives
+
+using KerbalEngineer.Extensions;
+
+#endregion
+
+namespace KerbalEngineer.Flight.Readouts.Rendezvous
+{
+    public class RelativeVelocity : ReadoutModule
+    {
+        #region Constructors
+
+        public RelativeVelocity()
+        {
+            this.Name = "Relative Velocity";
+            this.Category = ReadoutCategory.GetCategory("Rendezvous");
+            this.HelpString = "Shows the relative orbital velocity between your vessel and the target object.";
+            this.IsDefault = false;
+        }
+
+        #endregion
+
+        #region Methods: public
+
+        public override void Draw()
+        {
+            if (RendezvousProcessor.ShowDetails)
+            {
+                this.DrawLine(RendezvousProcessor.RelativeVelocity.ToSpeed());
+            }
+        }
+
+        public override void Reset()
+        {
+            FlightEngineerCore.Instance.AddUpdatable(RendezvousProcessor.Instance);
+        }
+
+        public override void Update()
+        {
+            RendezvousProcessor.RequestUpdate();
+        }
+
+        #endregion
+    }
+}

--- a/KerbalEngineer/Flight/Readouts/Rendezvous/RendezvousProcessor.cs
+++ b/KerbalEngineer/Flight/Readouts/Rendezvous/RendezvousProcessor.cs
@@ -19,11 +19,10 @@
 
 #region Using Directives
 
+using KerbalEngineer.Extensions;
 using System;
 
-using KerbalEngineer.Extensions;
 
-using UnityEngine;
 
 #endregion
 
@@ -73,6 +72,11 @@ namespace KerbalEngineer.Flight.Readouts.Rendezvous
         ///     Gets the angular difference between the origin and target orbits.
         /// </summary>
         public static double RelativeInclination { get; private set; }
+
+        /// <summary>
+        ///     Gets the relative orbital velocity between the your vessel and target.
+        /// </summary>
+        public static double RelativeVelocity { get; private set; }
 
         /// <summary>
         ///     Gets the time it will take to reach the ascending node.
@@ -161,13 +165,14 @@ namespace KerbalEngineer.Flight.Readouts.Rendezvous
                 ? FlightGlobals.ship_orbit
                 : FlightGlobals.ship_orbit.referenceBody.orbit;
 
+            RelativeVelocity = FlightGlobals.fetch.VesselTarget.GetObtVelocity().magnitude - FlightGlobals.ship_obtVelocity.magnitude;
             RelativeInclination = this.originOrbit.GetRelativeInclination(this.targetOrbit);
             PhaseAngle = this.originOrbit.GetPhaseAngle(this.targetOrbit);
             InterceptAngle = this.CalcInterceptAngle();
             TimeToAscendingNode = this.originOrbit.GetTimeToVector(this.GetAscendingNode());
             TimeToDescendingNode = this.originOrbit.GetTimeToVector(this.GetDescendingNode());
             AngleToAscendingNode = this.originOrbit.GetAngleToVector(this.GetAscendingNode());
-            AngleToDescendingNode =this.originOrbit.GetAngleToVector(this.GetDescendingNode());
+            AngleToDescendingNode = this.originOrbit.GetAngleToVector(this.GetDescendingNode());
             AltitudeSeaLevel = this.targetOrbit.altitude;
             ApoapsisHeight = this.targetOrbit.ApA;
             PeriapsisHeight = this.targetOrbit.PeA;

--- a/KerbalEngineer/KerbalEngineer.csproj
+++ b/KerbalEngineer/KerbalEngineer.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Flight\Readouts\Orbital\TrueAnomaly.cs" />
     <Compile Include="Flight\Readouts\Orbital\TimeToEquatorialAscendingNode.cs" />
     <Compile Include="Flight\Readouts\Orbital\TimeToEquatorialDescendingNode.cs" />
+    <Compile Include="Flight\Readouts\Rendezvous\RelativeVelocity.cs" />
     <Compile Include="Flight\Readouts\Rendezvous\SemiMinorAxis.cs" />
     <Compile Include="Flight\Readouts\Rendezvous\SemiMajorAxis.cs" />
     <Compile Include="Flight\Readouts\Rendezvous\TimeToRelativeDescendingNode.cs" />


### PR DESCRIPTION
I really want this feature to be there. Because it is the only feature I use from VOID plugin. It really helps approaching target.
