### PR TITLE
Fix for simulation staging issue reported on forum

### DIFF
--- a/KerbalEngineer/VesselSimulator/PartSim.cs
+++ b/KerbalEngineer/VesselSimulator/PartSim.cs
@@ -681,7 +681,7 @@ namespace KerbalEngineer.VesselSimulator
         {
             foreach (int type in types)
             {
-                if (this.resources.HasType(type) && this.resourceFlowStates[type] != 0 && (double)this.resources[type] > SimManager.RESOURCE_MIN)
+                if (this.resources.HasType(type) && this.resourceFlowStates[type] != 0 && (double)this.resources[type] > SimManager.RESOURCE_PART_EMPTY_THRESH)
                 {
                     return false;
                 }

--- a/KerbalEngineer/VesselSimulator/SimManager.cs
+++ b/KerbalEngineer/VesselSimulator/SimManager.cs
@@ -34,6 +34,7 @@ namespace KerbalEngineer.VesselSimulator
         #region Constants
 
         public const double RESOURCE_MIN = 0.0001;
+        public const double RESOURCE_PART_EMPTY_THRESH = 0.01;
 
         #endregion
 


### PR DESCRIPTION
Increased part empty resource threshold value.
Should greatly reduce the likelyhood of the simulation failing to stage off liquid boosters.
Simulation really needs to track which tanks are actually being drained from.