### PR TITLE
Changes required for build 1205 or later

### DIFF
--- a/KerbalEngineer/AppLauncherButton.cs
+++ b/KerbalEngineer/AppLauncherButton.cs
@@ -35,7 +35,7 @@ namespace KerbalEngineer
             get
             {
                 return m_Button != null &&
-                       m_Button.toggleButton.Button.interactable &&
+                       //m_Button.toggleButton.Button.interactable &&
                        m_Button.toggleButton.CurrentState == UIRadioButton.State.True;
             }
             set
@@ -61,7 +61,7 @@ namespace KerbalEngineer
         /// </summary>
         public void Disable()
         {
-            if (m_Button != null && m_Button.toggleButton.Button.interactable)
+            if (m_Button != null /*&& m_Button.toggleButton.Button.interactable*/)
             {
                 m_Button.Disable();
             }
@@ -72,7 +72,7 @@ namespace KerbalEngineer
         /// </summary>
         public void Enable()
         {
-            if (m_Button != null && m_Button.toggleButton.Button.interactable == false)
+            if (m_Button != null /*&& m_Button.toggleButton.Button.interactable == false*/)
             {
                 m_Button.Enable();
             }

--- a/KerbalEngineer/AppLauncherButton.cs
+++ b/KerbalEngineer/AppLauncherButton.cs
@@ -35,7 +35,7 @@ namespace KerbalEngineer
             get
             {
                 return m_Button != null &&
-                       //m_Button.toggleButton.Button.interactable &&
+                       m_Button.IsEnabled &&
                        m_Button.toggleButton.CurrentState == UIRadioButton.State.True;
             }
             set
@@ -61,7 +61,7 @@ namespace KerbalEngineer
         /// </summary>
         public void Disable()
         {
-            if (m_Button != null /*&& m_Button.toggleButton.Button.interactable*/)
+            if (m_Button != null && m_Button.IsEnabled)
             {
                 m_Button.Disable();
             }
@@ -72,7 +72,7 @@ namespace KerbalEngineer
         /// </summary>
         public void Enable()
         {
-            if (m_Button != null /*&& m_Button.toggleButton.Button.interactable == false*/)
+            if (m_Button != null && !m_Button.IsEnabled)
             {
                 m_Button.Enable();
             }

--- a/KerbalEngineer/Extensions/PartExtensions.cs
+++ b/KerbalEngineer/Extensions/PartExtensions.cs
@@ -100,7 +100,7 @@ namespace KerbalEngineer.Extensions
             {
                 PartModule pm = part.Modules[i];
                 if (pm is IPartCostModifier)
-                    cost += (pm as IPartCostModifier).GetModuleCost(defaultCost);
+                    cost += (pm as IPartCostModifier).GetModuleCost(defaultCost, ModifierStagingSituation.CURRENT);
             }
             return cost;
         }

--- a/KerbalEngineer/VesselSimulator/PartSim.cs
+++ b/KerbalEngineer/VesselSimulator/PartSim.cs
@@ -150,7 +150,7 @@ namespace KerbalEngineer.VesselSimulator
                 }
             }
 
-            partSim.fairingMass = partSim.part.GetModule<ModuleProceduralFairing>()?.GetModuleMass(partSim.part.mass) ?? 0.0f;
+            partSim.fairingMass = partSim.part.GetModule<ModuleProceduralFairing>()?.GetModuleMass(partSim.part.mass, ModifierStagingSituation.CURRENT) ?? 0.0f;
 
             for (int i = 0; i < partSim.part.Resources.Count; i++)
             {

--- a/KerbalEngineer/VesselSimulator/PartSim.cs
+++ b/KerbalEngineer/VesselSimulator/PartSim.cs
@@ -56,8 +56,8 @@ namespace KerbalEngineer.VesselSimulator
         public bool isLanded;
         public bool isNoPhysics;
         public bool isSepratron;
-        public bool isFairing;
-        public float fairingMass;
+        //public bool isFairing;
+        public float postStageMassAdjust;
         public int stageIndex;
         public String name;
         public String noCrossFeedNodeKey;
@@ -100,61 +100,77 @@ namespace KerbalEngineer.VesselSimulator
             pool.Release(this);
         }
 
-        public static PartSim New(Part thePart, int id, double atmosphere, LogMsg log)
+        public static PartSim New(Part p, int id, double atmosphere, LogMsg log)
         {
             PartSim partSim = pool.Borrow();
 
-            partSim.part = thePart;
-            partSim.centerOfMass = thePart.transform.TransformPoint(thePart.CoMOffset);
+            partSim.part = p;
+            partSim.centerOfMass = p.transform.TransformPoint(p.CoMOffset);
             partSim.partId = id;
-            partSim.name = partSim.part.partInfo.name;
+            partSim.name = p.partInfo.name;
 
             if (log != null) log.buf.AppendLine("Create PartSim for " + partSim.name);
 
             partSim.parent = null;
-            partSim.parentAttach = partSim.part.attachMode;
-            partSim.fuelCrossFeed = partSim.part.fuelCrossFeed;
-            partSim.noCrossFeedNodeKey = partSim.part.NoCrossFeedNodeKey;
-            partSim.decoupledInStage = partSim.DecoupledInStage(partSim.part);
-            partSim.isFuelLine = partSim.part.HasModule<CModuleFuelLine>();
-            partSim.isFuelTank = partSim.part is FuelTank;
+            partSim.parentAttach = p.attachMode;
+            partSim.fuelCrossFeed = p.fuelCrossFeed;
+            partSim.noCrossFeedNodeKey = p.NoCrossFeedNodeKey;
+            partSim.decoupledInStage = partSim.DecoupledInStage(p);
+            partSim.isFuelLine = p.HasModule<CModuleFuelLine>();
+            partSim.isFuelTank = p is FuelTank;
             partSim.isSepratron = partSim.IsSepratron();
-            partSim.inverseStage = partSim.part.inverseStage;
+            partSim.inverseStage = p.inverseStage;
             //MonoBehaviour.print("inverseStage = " + inverseStage);
 
-            partSim.baseCost = partSim.part.GetCostDry();
+            partSim.baseCost = p.GetCostDry();
 
             if (log != null)
             {
-                log.buf.AppendLine("Parent part = " + (partSim.part.parent == null ? "null" : partSim.part.parent.partInfo.name));
-                log.buf.AppendLine("physicalSignificance = " + partSim.part.physicalSignificance);
-                log.buf.AppendLine("PhysicsSignificance = " + partSim.part.PhysicsSignificance);
+                log.buf.AppendLine("Parent part = " + (p.parent == null ? "null" : p.parent.partInfo.name));
+                log.buf.AppendLine("physicalSignificance = " + p.physicalSignificance);
+                log.buf.AppendLine("PhysicsSignificance = " + p.PhysicsSignificance);
             }
 
             // Work out if the part should have no physical significance
             // The root part is never "no physics"
-            partSim.isNoPhysics = partSim.part.physicalSignificance == Part.PhysicalSignificance.NONE ||
-                                    partSim.part.PhysicsSignificance == 1;
+            partSim.isNoPhysics = p.physicalSignificance == Part.PhysicalSignificance.NONE ||
+                                    p.PhysicsSignificance == 1;
 
-            if (partSim.part.HasModule<LaunchClamp>())
+            if (p.HasModule<LaunchClamp>())
             {
                 partSim.realMass = 0d;
                 if (log != null) log.buf.AppendLine("Ignoring mass of launch clamp");
             }
             else
             {
-                partSim.realMass = partSim.part.mass;
-                if (log != null)
-                {
-                    log.buf.AppendLine("Using part.mass" + partSim.part.mass);
-                }
+                partSim.realMass = p.mass;
+                if (log != null) log.buf.AppendLine("Using part.mass of " + p.mass);
             }
 
-            partSim.fairingMass = partSim.part.GetModule<ModuleProceduralFairing>()?.GetModuleMass(partSim.part.mass, ModifierStagingSituation.CURRENT) ?? 0.0f;
-
-            for (int i = 0; i < partSim.part.Resources.Count; i++)
+            partSim.postStageMassAdjust = 0f;
+            if (log != null) log.buf.AppendLine("Calculating postStageMassAdjust, prefabMass = " + p.prefabMass);
+            int count = p.Modules.Count;
+            for (int i = 0; i < count; i++)
             {
-                PartResource resource = partSim.part.Resources[i];
+                if (log != null) log.buf.AppendLine("Module: " + p.Modules[i].moduleName);
+                IPartMassModifier partMassModifier = p.Modules[i] as IPartMassModifier;
+                if (partMassModifier != null)
+                {
+                    if (log != null) log.buf.AppendLine("ChangeWhen = " + partMassModifier.GetModuleMassChangeWhen());
+                    if (partMassModifier.GetModuleMassChangeWhen() == ModifierChangeWhen.STAGED)
+                    {
+                        float preStage = partMassModifier.GetModuleMass(p.prefabMass, ModifierStagingSituation.UNSTAGED);
+                        float postStage = partMassModifier.GetModuleMass(p.prefabMass, ModifierStagingSituation.STAGED);
+                        if (log != null) log.buf.AppendLine("preStage = " + preStage + "   postStage = " + postStage);
+                        partSim.postStageMassAdjust += (postStage - preStage);
+                    }
+                }
+            }
+            if (log != null) log.buf.AppendLine("postStageMassAdjust = " + partSim.postStageMassAdjust);
+
+            for (int i = 0; i < p.Resources.Count; i++)
+            {
+                PartResource resource = p.Resources[i];
 
                 // Make sure it isn't NaN as this messes up the part mass and hence most of the values
                 // This can happen if a resource capacity is 0 and tweakable
@@ -172,17 +188,17 @@ namespace KerbalEngineer.VesselSimulator
                 }
             }
 
-            partSim.hasVessel = (partSim.part.vessel != null);
-            partSim.isLanded = partSim.hasVessel && partSim.part.vessel.Landed;
+            partSim.hasVessel = (p.vessel != null);
+            partSim.isLanded = partSim.hasVessel && p.vessel.Landed;
             if (partSim.hasVessel)
             {
-                partSim.vesselName = partSim.part.vessel.vesselName;
-                partSim.vesselType = partSim.part.vesselType;
+                partSim.vesselName = p.vessel.vesselName;
+                partSim.vesselType = p.vesselType;
             }
-            partSim.initialVesselName = partSim.part.initialVesselName;
+            partSim.initialVesselName = p.initialVesselName;
 
-            partSim.hasMultiModeEngine = partSim.part.HasModule<MultiModeEngine>();
-            partSim.hasModuleEngines = partSim.part.HasModule<ModuleEngines>();
+            partSim.hasMultiModeEngine = p.HasModule<MultiModeEngine>();
+            partSim.hasModuleEngines = p.HasModule<ModuleEngines>();
 
             partSim.isEngine = partSim.hasMultiModeEngine || partSim.hasModuleEngines;
 
@@ -388,9 +404,9 @@ namespace KerbalEngineer.VesselSimulator
                 mass += resources.GetResourceMass(resources.Types[i]);
             }
 
-            if (fairingMass > 0.0 && currentStage <= inverseStage)
+            if (postStageMassAdjust != 0.0 && currentStage <= inverseStage)
             {
-                mass -= fairingMass;
+                mass += postStageMassAdjust;
             }
 
             return mass;


### PR DESCRIPTION
There are a couple of important (i.e. breaking) changes in build 1205 of KSP:

1. Disabling of app launcher buttons should now work (i.e. a disabled button won't give you clicks) but the UIRadioButton.Button member is now private.  I have simply removed the 3 references to the interactable member but have not yet tested to see if it works correctly.  I suspect it will need some further tweaks.

2. The IPartXXXModifier interfaces have been modified (mostly at my request) to make supporting other part modules that implement it easier.  So far I have simply added the extra parameter required by the GetModuleCost and GetModuleMass functions but this will almost certainly need checking and tweaking further.

I'm unable to test my changes at the moment as I am on a Win32 machine where KSP always runs out of address space before the main menu and can only remote desktop to my Win64 machine and Unity 5 broke that resulting in a black KSP window.

So, best not to merge this just yet until it's had a bit of testing and tweaking to make sure it doesn't do anything nasty.