### PR TITLE
Add flight readouts section for parameters of the currently active body

### DIFF
--- a/KerbalEngineer/Flight/Readouts/Body/BodyName.cs
+++ b/KerbalEngineer/Flight/Readouts/Body/BodyName.cs
@@ -1,0 +1,51 @@
+﻿// 
+//     Kerbal Engineer Redux
+// 
+//     Copyright (C) 2014 CYBUTEK
+// 
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+// 
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+// 
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// 
+
+#region Using Directives
+
+using KerbalEngineer.Flight.Sections;
+
+#endregion
+
+namespace KerbalEngineer.Flight.Readouts.Body
+{
+    public class BodyName : ReadoutModule
+    {
+        #region Constructors
+
+        public BodyName()
+        {
+            this.Name = "Current Body Name";
+            this.Category = ReadoutCategory.GetCategory("Body");
+            this.HelpString = "Shows the name of the current body.";
+            this.IsDefault = false;
+        }
+
+        #endregion
+
+        #region Methods: public
+
+        public override void Draw(SectionModule section)
+        {
+            this.DrawLine(FlightGlobals.ActiveVessel.mainBody.theName, section.IsHud);
+        }
+
+        #endregion
+    }
+}

--- a/KerbalEngineer/Flight/Readouts/Body/HasAtmosphere.cs
+++ b/KerbalEngineer/Flight/Readouts/Body/HasAtmosphere.cs
@@ -1,0 +1,51 @@
+﻿// 
+//     Kerbal Engineer Redux
+// 
+//     Copyright (C) 2014 CYBUTEK
+// 
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+// 
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+// 
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// 
+
+#region Using Directives
+
+using KerbalEngineer.Flight.Sections;
+
+#endregion
+
+namespace KerbalEngineer.Flight.Readouts.Body
+{
+    public class HasAtmosphere : ReadoutModule
+    {
+        #region Constructors
+
+        public HasAtmosphere()
+        {
+            this.Name = "Has Atmosphere";
+            this.Category = ReadoutCategory.GetCategory("Body");
+            this.HelpString = "Shows whether the current body has an atmosphere.";
+            this.IsDefault = false;
+        }
+
+        #endregion
+
+        #region Methods: public
+
+        public override void Draw(SectionModule section)
+        {
+            this.DrawLine(FlightGlobals.ActiveVessel.mainBody.atmosphere ? "Yes" : "No", section.IsHud);
+        }
+
+        #endregion
+    }
+}

--- a/KerbalEngineer/Flight/Readouts/Body/HighAtmosphereHeight.cs
+++ b/KerbalEngineer/Flight/Readouts/Body/HighAtmosphereHeight.cs
@@ -1,0 +1,55 @@
+﻿// 
+//     Kerbal Engineer Redux
+// 
+//     Copyright (C) 2014 CYBUTEK
+// 
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+// 
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+// 
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// 
+
+#region Using Directives
+
+using KerbalEngineer.Extensions;
+using KerbalEngineer.Flight.Sections;
+
+#endregion
+
+namespace KerbalEngineer.Flight.Readouts.Body
+{
+    public class HighAtmosphereHeight : ReadoutModule
+    {
+        #region Constructors
+
+        public HighAtmosphereHeight()
+        {
+            this.Name = "High Atmosphere Alt.";
+            this.Category = ReadoutCategory.GetCategory("Body");
+            this.HelpString = "The altitude where the upper atmosphere begins.";
+            this.IsDefault = true;
+        }
+
+        #endregion
+
+        #region Methods: public
+
+        public override void Draw(SectionModule section)
+        {
+            if (FlightGlobals.ActiveVessel.mainBody.atmosphere)
+            {
+                this.DrawLine(FlightGlobals.ActiveVessel.mainBody.scienceValues.flyingAltitudeThreshold.ToDistance(), section.IsHud);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/KerbalEngineer/Flight/Readouts/Body/HighSpaceHeight.cs
+++ b/KerbalEngineer/Flight/Readouts/Body/HighSpaceHeight.cs
@@ -1,0 +1,52 @@
+﻿// 
+//     Kerbal Engineer Redux
+// 
+//     Copyright (C) 2014 CYBUTEK
+// 
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+// 
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+// 
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// 
+
+#region Using Directives
+
+using KerbalEngineer.Extensions;
+using KerbalEngineer.Flight.Sections;
+
+#endregion
+
+namespace KerbalEngineer.Flight.Readouts.Body
+{
+    public class HighSpaceHeight : ReadoutModule
+    {
+        #region Constructors
+
+        public HighSpaceHeight()
+        {
+            this.Name = "High Space Alt.";
+            this.Category = ReadoutCategory.GetCategory("Body");
+            this.HelpString = "The altitude where upper space begins.";
+            this.IsDefault = true;
+        }
+
+        #endregion
+
+        #region Methods: public
+
+        public override void Draw(SectionModule section)
+        {
+            this.DrawLine(FlightGlobals.ActiveVessel.mainBody.scienceValues.spaceAltitudeThreshold.ToDistance(), section.IsHud);
+        }
+
+        #endregion
+    }
+}

--- a/KerbalEngineer/Flight/Readouts/Body/LowSpaceHeight.cs
+++ b/KerbalEngineer/Flight/Readouts/Body/LowSpaceHeight.cs
@@ -1,0 +1,55 @@
+﻿// 
+//     Kerbal Engineer Redux
+// 
+//     Copyright (C) 2014 CYBUTEK
+// 
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+// 
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+// 
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// 
+
+#region Using Directives
+
+using KerbalEngineer.Extensions;
+using KerbalEngineer.Flight.Sections;
+
+#endregion
+
+namespace KerbalEngineer.Flight.Readouts.Body
+{
+    public class LowSpaceHeight : ReadoutModule
+    {
+        #region Constructors
+
+        public LowSpaceHeight()
+        {
+            this.Name = "Low Space Alt.";
+            this.Category = ReadoutCategory.GetCategory("Body");
+            this.HelpString = "The altitude where lower space begins.";
+            this.IsDefault = true;
+        }
+
+        #endregion
+
+        #region Methods: public
+
+        public override void Draw(SectionModule section)
+        {
+            if (FlightGlobals.ActiveVessel.mainBody.atmosphere)
+            {
+                this.DrawLine(FlightGlobals.ActiveVessel.mainBody.atmosphereDepth.ToDistance(), section.IsHud);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/KerbalEngineer/Flight/Readouts/ReadoutLibrary.cs
+++ b/KerbalEngineer/Flight/Readouts/ReadoutLibrary.cs
@@ -28,6 +28,7 @@ namespace KerbalEngineer.Flight.Readouts
     using Surface;
     using Thermal;
     using Vessel;
+    using Body;
     using AltitudeSeaLevel = Surface.AltitudeSeaLevel;
     using ApoapsisHeight = Orbital.ApoapsisHeight;
     using OrbitalPeriod = Orbital.OrbitalPeriod;
@@ -53,6 +54,7 @@ namespace KerbalEngineer.Flight.Readouts
                 ReadoutCategory.SetCategory("Vessel", "Vessel performance statistics.");
                 ReadoutCategory.SetCategory("Rendezvous", "Readouts for rendezvous manovoeures.");
                 ReadoutCategory.SetCategory("Thermal", "Thermal characteristics readouts.");
+                ReadoutCategory.SetCategory("Body", "Characteristics of the current SOI.");
                 ReadoutCategory.SetCategory("Miscellaneous", "Miscellaneous readouts.");
                 ReadoutCategory.Selected = ReadoutCategory.GetCategory("Orbital");
 
@@ -185,6 +187,13 @@ namespace KerbalEngineer.Flight.Readouts
                 readouts.Add(new CoolestPart());
                 readouts.Add(new CoolestTemperature());
                 readouts.Add(new CoolestSkinTemperature());
+
+                // Body
+                readouts.Add(new BodyName());
+                readouts.Add(new HasAtmosphere());
+                readouts.Add(new HighAtmosphereHeight());
+                readouts.Add(new LowSpaceHeight());
+                readouts.Add(new HighSpaceHeight());
 
                 // Misc
                 readouts.Add(new Separator());

--- a/KerbalEngineer/Flight/Sections/SectionLibrary.cs
+++ b/KerbalEngineer/Flight/Sections/SectionLibrary.cs
@@ -75,7 +75,15 @@ namespace KerbalEngineer.Flight.Sections
                 ReadoutModules = ReadoutLibrary.GetCategory(ReadoutCategory.GetCategory("Thermal")).Where(r => r.IsDefault).ToList(),
                 IsCustom = true
             });
-            
+
+            CustomSections.Add(new SectionModule
+            {
+                Name = "BODY",
+                Abbreviation = "BODY",
+                ReadoutModules = ReadoutLibrary.GetCategory(ReadoutCategory.GetCategory("Body")).Where(r => r.IsDefault).ToList(),
+                IsCustom = true
+            });
+
             SectionModule hud1 = new SectionModule
             {
                 Name = "HUD 1",


### PR DESCRIPTION
Following some random musings on IRC, this is a first go of adding the following Readouts to KER under a new "Body" category.
- Current Body Name
- Has Atmosphere (Yes/No)
- High Atmosphere Alt.  (hidden if no atmosphere)
- Low Space Alt.  (hidden if no atmosphere)
- High Space Alt.

These -- combined with the already-available Biome display -- make some experiment running easier and avoid having to pull a wiki page.  

A few thoughts:
- I'm not super happy with the category name "Body".  I had originally thought "Science" but there's too many other things we could potentially display to include there.
- "Alt." should maybe be "Height" for consistency.
- Biome and SOI arguably might belong more under this category than their current placement, but I didn't want to refactor too much yet without knowing KER's structure that well yet.
- Not sure if Current Body Name should use .theName or just .bodyName/.name
