### PR TITLE
Target latitude and longitude

### DIFF
--- a/KerbalEngineer/Flight/Readouts/ReadoutLibrary.cs
+++ b/KerbalEngineer/Flight/Readouts/ReadoutLibrary.cs
@@ -170,6 +170,8 @@ namespace KerbalEngineer.Flight.Readouts
                 readouts.Add(new Rendezvous.SemiMinorAxis());
                 readouts.Add(new Rendezvous.RelativeRadialVelocity());
                 readouts.Add(new Rendezvous.TimeToRendezvous());
+                readouts.Add(new TargetLatitude());
+                readouts.Add(new TargetLongitude());
 
                 // Thermal
                 readouts.Add(new InternalFlux());

--- a/KerbalEngineer/Flight/Readouts/Rendezvous/TargetLatitude.cs
+++ b/KerbalEngineer/Flight/Readouts/Rendezvous/TargetLatitude.cs
@@ -1,0 +1,57 @@
+﻿// 
+//     Kerbal Engineer Redux
+// 
+//     Copyright (C) 2014 CYBUTEK
+// 
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+// 
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+// 
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// 
+
+#region Using Directives
+
+using KerbalEngineer.Flight.Sections;
+using KerbalEngineer.Helpers;
+
+#endregion
+
+namespace KerbalEngineer.Flight.Readouts.Surface
+{
+    public class TargetLatitude : ReadoutModule
+    {
+        #region Constructors
+
+        public TargetLatitude()
+        {
+            Name = "Target Latitude";
+            Category = ReadoutCategory.GetCategory("Rendezvous");
+            HelpString = "Shows the target vessel's latitude position around the celestial body. Latitude is the angle from the equator to poles.";
+            IsDefault = false;
+        }
+
+        #endregion
+
+        #region Methods: public
+
+        public override void Draw(SectionModule section)
+        {
+            var target = FlightGlobals.fetch.VesselTarget?.GetVessel();
+            if (target != null)
+            {
+                double latitude = AngleHelper.Clamp360(target.latitude);
+                DrawLine(Units.ToAngleDMS(latitude) + (latitude < 0 ? " S" : " N"), section.IsHud);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/KerbalEngineer/Flight/Readouts/Rendezvous/TargetLongitude.cs
+++ b/KerbalEngineer/Flight/Readouts/Rendezvous/TargetLongitude.cs
@@ -1,0 +1,45 @@
+﻿// 
+//     Kerbal Engineer Redux
+// 
+//     Copyright (C) 2014 CYBUTEK
+// 
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+// 
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+// 
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// 
+
+namespace KerbalEngineer.Flight.Readouts.Surface
+{
+    using Helpers;
+    using Sections;
+
+    public class TargetLongitude : ReadoutModule
+    {
+        public TargetLongitude()
+        {
+            Name = "Target Longitude";
+            Category = ReadoutCategory.GetCategory("Rendezvous");
+            HelpString = "Shows the target vessel's longitude around a celestial body. Longitude is the angle from the bodies prime meridian.";
+            IsDefault = true;
+        }
+
+        public override void Draw(SectionModule section)
+        {
+            var target = FlightGlobals.fetch.VesselTarget?.GetVessel();
+            if (target != null)
+            {
+                double longitude = AngleHelper.Clamp180(target.longitude);
+                DrawLine(Units.ToAngleDMS(longitude) + (longitude < 0.0 ? "W" : " E"), section.IsHud);
+            }
+        }
+    }
+}

--- a/KerbalEngineer/Flight/Readouts/Rendezvous/TargetLongitude.cs
+++ b/KerbalEngineer/Flight/Readouts/Rendezvous/TargetLongitude.cs
@@ -29,7 +29,7 @@ namespace KerbalEngineer.Flight.Readouts.Surface
             Name = "Target Longitude";
             Category = ReadoutCategory.GetCategory("Rendezvous");
             HelpString = "Shows the target vessel's longitude around a celestial body. Longitude is the angle from the bodies prime meridian.";
-            IsDefault = true;
+            IsDefault = false;
         }
 
         public override void Draw(SectionModule section)

--- a/KerbalEngineer/Helpers/AngleHelper.cs
+++ b/KerbalEngineer/Helpers/AngleHelper.cs
@@ -25,20 +25,42 @@ namespace KerbalEngineer.Helpers
     {
         public static double Clamp180(double angle)
         {
-            angle = Clamp360(angle);
-            if (angle > 180.0)
+            if (angle < -180.0)
             {
-                angle = angle - 360.0;
+                do
+                {
+                    angle += 360.0;
+                }
+                while (angle < -180.0);
+            }
+            else if (angle > 180.0)
+            {
+                do
+                {
+                    angle -= 360.0;
+                }
+                while (angle > 180.0);
             }
             return angle;
         }
 
         public static double Clamp360(double angle)
         {
-            angle = angle % 360.0;
             if (angle < 0.0)
             {
-                angle = angle + 360.0;
+                do
+                {
+                    angle += 360.0;
+                }
+                while (angle < 0.0);
+            }
+            else if (angle > 360.0)
+            {
+                do
+                {
+                    angle -= 360.0;
+                }
+                while (angle > 360.0);
             }
             return angle;
         }

--- a/KerbalEngineer/KerbalEngineer.csproj
+++ b/KerbalEngineer/KerbalEngineer.csproj
@@ -96,6 +96,8 @@
     <Compile Include="Flight\Readouts\Rendezvous\RelativeVelocity.cs" />
     <Compile Include="Flight\Readouts\Rendezvous\SemiMinorAxis.cs" />
     <Compile Include="Flight\Readouts\Rendezvous\SemiMajorAxis.cs" />
+    <Compile Include="Flight\Readouts\Rendezvous\TargetLatitude.cs" />
+    <Compile Include="Flight\Readouts\Rendezvous\TargetLongitude.cs" />
     <Compile Include="Flight\Readouts\Rendezvous\TimeToRelativeDescendingNode.cs" />
     <Compile Include="Flight\Readouts\Rendezvous\TimeToRelativeAscendingNode.cs" />
     <Compile Include="Flight\Readouts\Surface\ImpactBiome.cs" />


### PR DESCRIPTION
Added readouts to rendezvous section as requested in forum.

Note, these readouts only operate when a vessel is the target, not a celestial body.  This could be added fairly easily but I couldn't really see the point.