### PR TITLE
Fix for staged docking ports

### DIFF
--- a/KerbalEngineer/Extensions/DoubleExtensions.cs
+++ b/KerbalEngineer/Extensions/DoubleExtensions.cs
@@ -68,6 +68,11 @@ namespace KerbalEngineer.Extensions
             return Units.ToPercent(value);
         }
 
+        public static string ToPressure(this double value)
+        {
+            return Units.ToPressure(value);
+        }
+
         public static string ToRate(this double value)
         {
             return Units.ToRate(value);

--- a/KerbalEngineer/Flight/Readouts/ReadoutLibrary.cs
+++ b/KerbalEngineer/Flight/Readouts/ReadoutLibrary.cs
@@ -112,6 +112,7 @@ namespace KerbalEngineer.Flight.Readouts
                 readouts.Add(new GeeForce());
                 readouts.Add(new TerminalVelocity());
                 readouts.Add(new AtmosphericEfficiency());
+                readouts.Add(new AtmosphericPressure());
                 readouts.Add(new Biome());
                 readouts.Add(new Situation());
                 readouts.Add(new Slope());

--- a/KerbalEngineer/Flight/Readouts/Surface/AtmosphericPressure.cs
+++ b/KerbalEngineer/Flight/Readouts/Surface/AtmosphericPressure.cs
@@ -36,7 +36,7 @@ namespace KerbalEngineer.Flight.Readouts.Surface
         {
             if (AtmosphericProcessor.ShowDetails)
             {
-                DrawLine(AtmosphericProcessor.DynamicPressure.ToPressure(), section.IsHud);
+                DrawLine(AtmosphericProcessor.StaticPressure.ToPressure(), section.IsHud);
             }
         }
 

--- a/KerbalEngineer/Flight/Readouts/Surface/AtmosphericPressure.cs
+++ b/KerbalEngineer/Flight/Readouts/Surface/AtmosphericPressure.cs
@@ -1,0 +1,53 @@
+﻿// 
+//     Kerbal Engineer Redux
+// 
+//     Copyright (C) 2015 CYBUTEK
+// 
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+// 
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+// 
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// 
+
+namespace KerbalEngineer.Flight.Readouts.Surface
+{
+    using Extensions;
+    using Sections;
+
+    public class AtmosphericPressure : ReadoutModule
+    {
+        public AtmosphericPressure()
+        {
+            Name = "Atmos. Pressure";
+            Category = ReadoutCategory.GetCategory("Surface");
+            HelpString = "Displays the current atmospheric pressure.";
+            IsDefault = false;
+        }
+
+        public override void Draw(SectionModule section)
+        {
+            if (AtmosphericProcessor.ShowDetails)
+            {
+                DrawLine(AtmosphericProcessor.DynamicPressure.ToPressure(), section.IsHud);
+            }
+        }
+
+        public override void Reset()
+        {
+            FlightEngineerCore.Instance.AddUpdatable(AtmosphericProcessor.Instance);
+        }
+
+        public override void Update()
+        {
+            AtmosphericProcessor.RequestUpdate();
+        }
+    }
+}

--- a/KerbalEngineer/Flight/Readouts/Surface/AtmosphericProcessor.cs
+++ b/KerbalEngineer/Flight/Readouts/Surface/AtmosphericProcessor.cs
@@ -97,6 +97,16 @@ namespace KerbalEngineer.Flight.Readouts.Surface
         /// </summary>
         public static double TerminalVelocity { get; private set; }
 
+        /// <summary>
+        ///     Gets the static pressure of the active vessel.
+        /// </summary>
+        public static double StaticPressure { get; private set; }
+
+        /// <summary>
+        ///     Gets the dynamic pressure of the active vessel.
+        /// </summary>
+        public static double DynamicPressure { get; private set; }
+
         #endregion
 
         #region IUpdatable Members
@@ -134,6 +144,9 @@ namespace KerbalEngineer.Flight.Readouts.Surface
                     var c = PhysicsGlobals.DragMultiplier;
 
                     TerminalVelocity = Math.Sqrt((2.0 * m * g) / (p * a * c));
+
+                    StaticPressure = FlightGlobals.ActiveVessel.staticPressurekPa;
+                    DynamicPressure = FlightGlobals.ActiveVessel.dynamicPressurekPa;
                 }
 
                 Efficiency = FlightGlobals.ship_srfSpeed / TerminalVelocity;

--- a/KerbalEngineer/Flight/Readouts/Surface/ImpactLongitude.cs
+++ b/KerbalEngineer/Flight/Readouts/Surface/ImpactLongitude.cs
@@ -47,7 +47,7 @@ namespace KerbalEngineer.Flight.Readouts.Surface
         {
             if (ImpactProcessor.ShowDetails)
             {
-                this.DrawLine(Units.ToAngleDMS(ImpactProcessor.Longitude) + (ImpactProcessor.Longitude < 0.0 ? "W" : " E"), section.IsHud);
+                this.DrawLine(Units.ToAngleDMS(ImpactProcessor.Longitude) + (ImpactProcessor.Longitude < 0.0 ? " W" : " E"), section.IsHud);
             }
         }
 

--- a/KerbalEngineer/Flight/Readouts/Surface/Longitude.cs
+++ b/KerbalEngineer/Flight/Readouts/Surface/Longitude.cs
@@ -35,7 +35,7 @@ namespace KerbalEngineer.Flight.Readouts.Surface
         public override void Draw(SectionModule section)
         {
             double angle = AngleHelper.Clamp180(FlightGlobals.ship_longitude);
-            DrawLine(Units.ToAngleDMS(angle) + (angle < 0.0 ? "W" : " E"), section.IsHud);
+            DrawLine(Units.ToAngleDMS(angle) + (angle < 0.0 ? " W" : " E"), section.IsHud);
         }
     }
 }

--- a/KerbalEngineer/Flight/Readouts/Vessel/IntakeAirDemandSupply.cs
+++ b/KerbalEngineer/Flight/Readouts/Vessel/IntakeAirDemandSupply.cs
@@ -42,7 +42,7 @@ namespace KerbalEngineer.Flight.Readouts.Vessel
         {
             this.Name = "Intake Air (D/S)";
             this.Category = ReadoutCategory.GetCategory("Vessel");
-            this.HelpString = "Displays the Ration between required and available Intake Air.";
+            this.HelpString = "Displays the Ratio between required and available Intake Air.";
             this.IsDefault = false;
         }
 

--- a/KerbalEngineer/Helpers/Units.cs
+++ b/KerbalEngineer/Helpers/Units.cs
@@ -176,6 +176,11 @@ namespace KerbalEngineer.Helpers
             return value.ToString("F" + decimals) + "%";
         }
 
+        public static string ToPressure(double value)
+        {
+            return value.ToString((value < 100000.0) ? (value < 10000.0) ? (value < 100.0) ? (Math.Abs(value) < double.Epsilon) ? "N0" : "N3" : "N2" : "N1" : "N0") + "kN/m²";
+        }
+
         public static string ToRate(double value, int decimals = 1)
         {
             return value < 1.0 ? (value * 60.0).ToString("F" + decimals) + "/min" : value.ToString("F" + decimals) + "/sec";

--- a/KerbalEngineer/KerbalEngineer.csproj
+++ b/KerbalEngineer/KerbalEngineer.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Flight\Readouts\Rendezvous\TargetLongitude.cs" />
     <Compile Include="Flight\Readouts\Rendezvous\TimeToRelativeDescendingNode.cs" />
     <Compile Include="Flight\Readouts\Rendezvous\TimeToRelativeAscendingNode.cs" />
+    <Compile Include="Flight\Readouts\Surface\AtmosphericPressure.cs" />
     <Compile Include="Flight\Readouts\Surface\ImpactBiome.cs" />
     <Compile Include="Flight\Readouts\Surface\Slope.cs" />
     <Compile Include="Flight\Readouts\Surface\Biome.cs" />

--- a/KerbalEngineer/VesselSimulator/PartSim.cs
+++ b/KerbalEngineer/VesselSimulator/PartSim.cs
@@ -940,7 +940,14 @@ namespace KerbalEngineer.VesselSimulator
         private bool IsDecoupler(Part thePart)
         {
             PartExtensions.ProtoModuleDecoupler protoDecoupler = thePart.GetProtoModuleDecoupler();
-            return protoDecoupler != null && protoDecoupler.IsStageEnabled;
+            if (protoDecoupler != null && protoDecoupler.IsStageEnabled)
+                return true;
+
+            ModuleDockingNode modDock = thePart.GetModule<ModuleDockingNode>();
+            if (modDock != null && modDock.IsStageable())
+                return true;
+
+            return false;
         }
 
         private bool IsSepratron()


### PR DESCRIPTION
Issue reported on the forum.  Changed PartSim.IsDecoupler to return true for staging enabled docking ports.  Could potentially implement a ProtoModuleDockingNode if the build overlay wanted to display the info, but this fixes the calculations so will do for now.

