### PR TITLE
Correctly compute relative velocity when target is in different SOI

### DIFF
--- a/KerbalEngineer/Flight/Readouts/Rendezvous/RendezvousProcessor.cs
+++ b/KerbalEngineer/Flight/Readouts/Rendezvous/RendezvousProcessor.cs
@@ -182,7 +182,16 @@ namespace KerbalEngineer.Flight.Readouts.Rendezvous
                 : FlightGlobals.ship_orbit.referenceBody.orbit;
 
             RelativeInclination = originOrbit.GetRelativeInclination(targetOrbit);
-            RelativeVelocity = FlightGlobals.ship_tgtSpeed;
+
+            if (targetOrbit.referenceBody == FlightGlobals.ship_orbit.referenceBody)
+            {
+                RelativeVelocity = FlightGlobals.ship_tgtSpeed;
+            }
+            else
+            {
+                RelativeVelocity = (FlightGlobals.ship_orbit.GetFrameVel() - targetOrbit.GetFrameVel()).magnitude;
+            }
+
             RelativeSpeed = FlightGlobals.ship_obtSpeed - targetOrbit.orbitalSpeed;
             PhaseAngle = originOrbit.GetPhaseAngle(targetOrbit);
             InterceptAngle = CalcInterceptAngle(targetOrbit, originOrbit);


### PR DESCRIPTION
FlightGlobals.ship_tgtSpeed is not correct when the target is in a different SOI. Fixed by subtracting the GetFrameVel() values instead.