### PR TITLE
Add System Time (24h) readout

### DIFF
--- a/KerbalEngineer/Flight/Readouts/Miscellaneous/SystemDateTime.cs
+++ b/KerbalEngineer/Flight/Readouts/Miscellaneous/SystemDateTime.cs
@@ -30,17 +30,17 @@ using UnityEngine;
 
 namespace KerbalEngineer.Flight.Readouts.Miscellaneous
 {
-    public class SystemTime : ReadoutModule
+    public class SystemDateTime : ReadoutModule
     {
 
 
         #region Constructors
 
-        public SystemTime()
+        public SystemDateTime()
         {
             this.Name = "System Time";
             this.Category = ReadoutCategory.GetCategory("Miscellaneous");
-            this.HelpString = "Shows the System Time in 12 hour format (AM/PM)";
+            this.HelpString = "Shows the System Date/Time in ISO 8601 format";
             this.IsDefault = false;
         }
 
@@ -50,8 +50,8 @@ namespace KerbalEngineer.Flight.Readouts.Miscellaneous
 
         public override void Draw(SectionModule section)
         {
-            this.DrawLine(DateTime.Now.ToString("h:mm:ss tt"), section.IsHud);
-        } 
+            this.DrawLine(DateTime.Now.ToString("yyyy-MM-dd, HH:mm:ss"), section.IsHud);
+        }
 
         #endregion
 

--- a/KerbalEngineer/Flight/Readouts/Miscellaneous/SystemTime24.cs
+++ b/KerbalEngineer/Flight/Readouts/Miscellaneous/SystemTime24.cs
@@ -30,17 +30,17 @@ using UnityEngine;
 
 namespace KerbalEngineer.Flight.Readouts.Miscellaneous
 {
-    public class SystemTime : ReadoutModule
+    public class SystemTime24 : ReadoutModule
     {
 
 
         #region Constructors
 
-        public SystemTime()
+        public SystemTime24()
         {
             this.Name = "System Time";
             this.Category = ReadoutCategory.GetCategory("Miscellaneous");
-            this.HelpString = "Shows the System Time in 12 hour format (AM/PM)";
+            this.HelpString = "Shows the System Time in 24 hour format";
             this.IsDefault = false;
         }
 
@@ -50,8 +50,8 @@ namespace KerbalEngineer.Flight.Readouts.Miscellaneous
 
         public override void Draw(SectionModule section)
         {
-            this.DrawLine(DateTime.Now.ToString("h:mm:ss tt"), section.IsHud);
-        } 
+            this.DrawLine(DateTime.Now.ToString("HH:mm:ss"), section.IsHud);
+        }
 
         #endregion
 

--- a/KerbalEngineer/Flight/Readouts/ReadoutLibrary.cs
+++ b/KerbalEngineer/Flight/Readouts/ReadoutLibrary.cs
@@ -203,6 +203,8 @@ namespace KerbalEngineer.Flight.Readouts
                 readouts.Add(new SimulationDelay());
                 readouts.Add(new VectoredThrustToggle());
                 readouts.Add(new SystemTime());
+                readouts.Add(new SystemTime24());
+                readouts.Add(new SystemDateTime());
                 readouts.Add(new LogSimToggle());
 
                 LoadHelpStrings();

--- a/KerbalEngineer/KerbalEngineer.csproj
+++ b/KerbalEngineer/KerbalEngineer.csproj
@@ -61,6 +61,8 @@
     <Compile Include="Flight\Readouts\Body\HighSpaceHeight.cs" />
     <Compile Include="Flight\Readouts\Body\LowSpaceHeight.cs" />
     <Compile Include="Flight\Readouts\Miscellaneous\LogSimToggle.cs" />
+    <Compile Include="Flight\Readouts\Miscellaneous\SystemDateTime.cs" />
+    <Compile Include="Flight\Readouts\Miscellaneous\SystemTime24.cs" />
     <Compile Include="Flight\Readouts\Miscellaneous\SystemTime.cs" />
     <Compile Include="Flight\Readouts\Miscellaneous\VectoredThrustToggle.cs" />
     <Compile Include="Flight\Readouts\Miscellaneous\Separator.cs" />


### PR DESCRIPTION
 Add 2 new readouts:
* System Time in 24 hour format 
* System Date/Time in ISO 8601 format.

Change System Time (12h) readout with explicit `ToString("h:mm:ss tt")`, so if sometimes  «forced 
 en-US locale bug» fixed, user still would have 12h/24h choice.

All of them have title «System Time» because users don't want to stare at long clarification (System Time (24h), etc.) all the time at HUD. 
