### PR TITLE
Use resultingThrust instead of finalThrust for active engine calculations

### DIFF
--- a/KerbalEngineer/VesselSimulator/EngineSim.cs
+++ b/KerbalEngineer/VesselSimulator/EngineSim.cs
@@ -100,7 +100,7 @@ namespace KerbalEngineer.VesselSimulator
             bool throttleLocked = engineMod.throttleLocked || fullThrust;
             List<Propellant> propellants = engineMod.propellants;
             bool active = engineMod.isOperational;
-            float resultingThrust = engineMod.resultingThrust;
+            float finalThrust = engineMod.finalThrust;
             bool isFlamedOut = engineMod.flameout;
 			
 			EngineSim engineSim = pool.Borrow();
@@ -124,7 +124,7 @@ namespace KerbalEngineer.VesselSimulator
                 float flowModifier = GetFlowModifier(atmChangeFlow, atmCurve, engineSim.partSim.part.atmDensity, velCurve, machNumber, ref engineSim.maxMach);
                 engineSim.isp = atmosphereCurve.Evaluate((float)atmosphere);
                 engineSim.thrust = GetThrust(Mathf.Lerp(minFuelFlow, maxFuelFlow, GetThrustPercent(thrustPercentage)) * flowModifier, engineSim.isp);
-                engineSim.actualThrust = engineSim.isActive ? resultingThrust : 0.0;
+                engineSim.actualThrust = engineSim.isActive ? finalThrust : 0.0;
                 if (log != null)
                 {
                     log.buf.AppendFormat("flowMod = {0:g6}\n", flowModifier);


### PR DESCRIPTION
`resultingThrust` seems to be a temporary intermediate value in stock `ModuleEngines`. It is only set by `RequiredPropellantMass`, and only read by the calling function, `CalculateThrust`. It is not written by SolverEngines mod (used by Advanced Jet Engine and RealFuels), nor is it read by any other mod in my collection than Kerbal Engineer.

`finalThrust` will most of the time contain the same value as `resultingThrust`. It is modulated by received fuel fraction (of requested fuel amount), which should be 1.0 except on last tick when running out of fuel, and EnginePower multiplier which seems to be a disabled experience bonus and is also set to 1.0. If either of these features are expanded in another mod or in a future update, `finalThrust` will most likely be the correct value to use as it is the thrust that actually affects the vessel.

`finalThrust` is zeroed when time warping or when engine is not active, but in these situations `resultingThrust` contains a stale value, and is ignored by Kerbal Engineer anyway.

---

**TL;DR:** This change should fix the glaring incompatibility between Kerbal Engineer and RealFuels (or AJE), where thrust, acceleration, Isp and even remaining dV on current stage go to zero whenever engines are active.