### PR TITLE
Helper classes overall cleanup

### DIFF
--- a/KerbalEngineer/Extensions/OrbitExtensions.cs
+++ b/KerbalEngineer/Extensions/OrbitExtensions.cs
@@ -20,9 +20,7 @@
 #region Using Directives
 
 using System;
-
 using KerbalEngineer.Helpers;
-
 using UnityEngine;
 
 #endregion
@@ -32,9 +30,6 @@ namespace KerbalEngineer.Extensions
     public static class OrbitExtensions
     {
         #region Constants
-
-        public const double Tau = Math.PI * 2.0;
-
         #endregion
 
         #region Methods: public
@@ -57,19 +52,17 @@ namespace KerbalEngineer.Extensions
         public static double GetAngleToPrograde(this Orbit orbit, double universalTime)
         {
             if (orbit.referenceBody == CelestialBodies.SystemBody.CelestialBody)
-            {
-                return 0.0;
-            }
+                return 0;
 
             Vector3d orbitVector = orbit.getRelativePositionAtUT(universalTime);
-            orbitVector.z = 0.0;
+            orbitVector.z = 0;
 
             Vector3d bodyVector = orbit.referenceBody.orbit.getOrbitalVelocityAtUT(universalTime);
-            bodyVector.z = 0.0;
+            bodyVector.z = 0;
 
             double angle = AngleHelper.GetAngleBetweenVectors(bodyVector, orbitVector);
 
-            return AngleHelper.Clamp360(orbit.inclination < 90.0 ? angle : 360.0 - angle);
+            return AngleHelper.Clamp360(orbit.inclination < 90 ? angle : 360 - angle);
         }
 
         public static double GetAngleToRetrograde(this Orbit orbit)
@@ -80,24 +73,22 @@ namespace KerbalEngineer.Extensions
         public static double GetAngleToRetrograde(this Orbit orbit, double universalTime)
         {
             if (orbit.referenceBody == CelestialBodies.SystemBody.CelestialBody)
-            {
-                return 0.0;
-            }
+                return 0;
 
             Vector3d orbitVector = orbit.getRelativePositionAtUT(universalTime);
-            orbitVector.z = 0.0;
+            orbitVector.z = 0;
 
             Vector3d bodyVector = orbit.referenceBody.orbit.getOrbitalVelocityAtUT(universalTime);
-            bodyVector.z = 0.0;
+            bodyVector.z = 0;
 
             double angle = AngleHelper.GetAngleBetweenVectors(-bodyVector, orbitVector);
 
-            return AngleHelper.Clamp360(orbit.inclination < 90.0 ? angle : 360.0 - angle);
+            return AngleHelper.Clamp360(orbit.inclination < 90 ? angle : 360 - angle);
         }
 
         public static double GetAngleToTrueAnomaly(this Orbit orbit, double trueAnomaly)
         {
-            return AngleHelper.Clamp360(trueAnomaly - (orbit.trueAnomaly * Units.RAD_TO_DEG));
+            return AngleHelper.Clamp360(trueAnomaly - (orbit.trueAnomaly * Mathf.Rad2Deg));
         }
 
         public static double GetAngleToVector(this Orbit orbit, Vector3d vector)
@@ -107,8 +98,8 @@ namespace KerbalEngineer.Extensions
 
         public static double GetPhaseAngle(this Orbit orbit, Orbit target)
         {
-            var angle = AngleHelper.GetAngleBetweenVectors(Vector3d.Exclude(orbit.GetOrbitNormal(), target.pos), orbit.pos);
-            return (orbit.semiMajorAxis < target.semiMajorAxis) ? angle : angle - 360.0;
+            double angle = AngleHelper.GetAngleBetweenVectors(Vector3d.Exclude(orbit.GetOrbitNormal(), target.pos), orbit.pos);
+            return (orbit.semiMajorAxis < target.semiMajorAxis) ? angle : angle - 360;
         }
 
         public static double GetRelativeInclination(this Orbit orbit, Orbit target)
@@ -128,8 +119,8 @@ namespace KerbalEngineer.Extensions
 
         public static double GetTimeToTrueAnomaly(this Orbit orbit, double trueAnomaly)
         {
-            var time = orbit.GetDTforTrueAnomaly(trueAnomaly * Mathf.Deg2Rad, orbit.period);
-            return time < 0.0 ? time + orbit.period : time;
+            double time = orbit.GetDTforTrueAnomaly(trueAnomaly * Mathf.Deg2Rad, orbit.period);
+            return time < 0 ? time + orbit.period : time;
         }
 
         public static double GetTimeToVector(this Orbit orbit, Vector3d vector)
@@ -144,12 +135,12 @@ namespace KerbalEngineer.Extensions
 
         public static double GetTrueAnomalyOfAscendingNode(this Orbit orbit)
         {
-            return 360.0 - orbit.argumentOfPeriapsis;
+            return 360 - orbit.argumentOfPeriapsis;
         }
 
         public static double GetTrueAnomalyOfDescendingNode(this Orbit orbit)
         {
-            return 180.0 - orbit.argumentOfPeriapsis;
+            return 180 - orbit.argumentOfPeriapsis;
         }
 
         #endregion

--- a/KerbalEngineer/Extensions/OrbitExtensions.cs
+++ b/KerbalEngineer/Extensions/OrbitExtensions.cs
@@ -62,7 +62,7 @@ namespace KerbalEngineer.Extensions
 
             double angle = AngleHelper.GetAngleBetweenVectors(bodyVector, orbitVector);
 
-            return AngleHelper.Clamp360(orbit.inclination < 90 ? angle : 360 - angle);
+            return AngleHelper.Modulo360(orbit.inclination < 90 ? angle : 360 - angle);
         }
 
         public static double GetAngleToRetrograde(this Orbit orbit)
@@ -83,12 +83,12 @@ namespace KerbalEngineer.Extensions
 
             double angle = AngleHelper.GetAngleBetweenVectors(-bodyVector, orbitVector);
 
-            return AngleHelper.Clamp360(orbit.inclination < 90 ? angle : 360 - angle);
+            return AngleHelper.Modulo360(orbit.inclination < 90 ? angle : 360 - angle);
         }
 
         public static double GetAngleToTrueAnomaly(this Orbit orbit, double trueAnomaly)
         {
-            return AngleHelper.Clamp360(trueAnomaly - (orbit.trueAnomaly * Mathf.Rad2Deg));
+            return AngleHelper.Modulo360(trueAnomaly - (orbit.trueAnomaly * Mathf.Rad2Deg));
         }
 
         public static double GetAngleToVector(this Orbit orbit, Vector3d vector)

--- a/KerbalEngineer/Extensions/RectExtensions.cs
+++ b/KerbalEngineer/Extensions/RectExtensions.cs
@@ -41,7 +41,7 @@ namespace KerbalEngineer.Extensions
         /// <summary>
         ///     Clamps the rectangle into the screen region by the specified margin.
         /// </summary>
-        public static Rect ClampToScreen(this Rect value, float margin = 25.0f)
+        public static Rect ClampToScreen(this Rect value, float margin = 25)
         {
             value.x = Mathf.Clamp(value.x, -(value.width - margin), Screen.width - margin);
             value.y = Mathf.Clamp(value.y, -(value.height - margin), Screen.height - margin);

--- a/KerbalEngineer/Extensions/StringExtensions.cs
+++ b/KerbalEngineer/Extensions/StringExtensions.cs
@@ -25,7 +25,7 @@ namespace KerbalEngineer.Extensions
         {
             if (value != null && value.Length > length)
             {
-                value = value.Substring(0, length) + "...";
+                return value.Substring(0, length) + "...";
             }
             return value;
         }

--- a/KerbalEngineer/Flight/Readouts/Rendezvous/RendezvousProcessor.cs
+++ b/KerbalEngineer/Flight/Readouts/Rendezvous/RendezvousProcessor.cs
@@ -216,7 +216,7 @@ namespace KerbalEngineer.Flight.Readouts.Rendezvous
             double targetRadius = (targetOrbit.semiMinorAxis + targetOrbit.semiMajorAxis) * 0.5;
             double angle = 180.0 * (1.0 - Math.Pow((originRadius + targetRadius) / (2.0 * targetRadius), 1.5));
             angle = PhaseAngle - angle;
-            return RelativeInclination < 90.0 ? AngleHelper.Clamp360(angle) : AngleHelper.Clamp360(360.0 - (180.0 - angle));
+            return RelativeInclination < 90.0 ? AngleHelper.Modulo360(angle) : AngleHelper.Modulo360(360.0 - (180.0 - angle));
         }
 
         private Vector3d GetAscendingNode(Orbit targetOrbit, Orbit originOrbit)

--- a/KerbalEngineer/Flight/Readouts/Rendezvous/TargetLatitude.cs
+++ b/KerbalEngineer/Flight/Readouts/Rendezvous/TargetLatitude.cs
@@ -48,7 +48,7 @@ namespace KerbalEngineer.Flight.Readouts.Surface
             if (target != null)
             {
                 var vessel = target.GetVessel();
-                double latitude = AngleHelper.Clamp180(vessel.latitude);
+                double latitude = AngleHelper.Modulo180(vessel.latitude);
                 DrawLine(Units.ToAngleDMS(latitude) + (latitude < 0 ? " S" : " N"), section.IsHud);
             }
         }

--- a/KerbalEngineer/Flight/Readouts/Rendezvous/TargetLongitude.cs
+++ b/KerbalEngineer/Flight/Readouts/Rendezvous/TargetLongitude.cs
@@ -38,7 +38,7 @@ namespace KerbalEngineer.Flight.Readouts.Surface
             if (target != null)
             {
                 var vessel = target.GetVessel();
-                double longitude = AngleHelper.Clamp180(vessel.longitude);
+                double longitude = AngleHelper.Modulo180(vessel.longitude);
                 DrawLine(Units.ToAngleDMS(longitude) + (longitude < 0.0 ? " W" : " E"), section.IsHud);
             }
         }

--- a/KerbalEngineer/Flight/Readouts/Surface/Longitude.cs
+++ b/KerbalEngineer/Flight/Readouts/Surface/Longitude.cs
@@ -34,7 +34,7 @@ namespace KerbalEngineer.Flight.Readouts.Surface
 
         public override void Draw(SectionModule section)
         {
-            double angle = AngleHelper.Clamp180(FlightGlobals.ship_longitude);
+            double angle = AngleHelper.Modulo180(FlightGlobals.ship_longitude);
             DrawLine(Units.ToAngleDMS(angle) + (angle < 0.0 ? " W" : " E"), section.IsHud);
         }
     }

--- a/KerbalEngineer/Helpers/AngleHelper.cs
+++ b/KerbalEngineer/Helpers/AngleHelper.cs
@@ -21,40 +21,22 @@ namespace KerbalEngineer.Helpers
     public static class AngleHelper
     {
         /// <summary>
-        ///     Same as ClampBetween(angle, -180, 180).
+        ///     Same as ModuloBetween(angle, -180, 180).
         /// </summary>
-        public static double Clamp180(double angle)
+        public static double Modulo180(double angle)
         {
-            if (angle.IsValid())
-            {
-                while (angle < -180d)
-                    angle += 360d;
-
-                while (angle >= 180d)
-                    angle -= 360d;
-            }
-
-            return angle;
+            return ModuloBetween(angle, -180, 180);
         }
 
         /// <summary>
-        ///     Same as ClampBetween(angle, 0, 360).
+        ///     Same as ModuloBetween(angle, 0, 360).
         /// </summary>
-        public static double Clamp360(double angle)
+        public static double Modulo360(double angle)
         {
-            if (angle.IsValid())
-            {
-                while (angle < 0d)
-                    angle += 360d;
-
-                while (angle >= 360d)
-                    angle -= 360d;
-            }
-
-            return angle;
+            return ModuloBetween(angle, 0, 360);
         }
 
-        public static double ClampBetween(double value, double minimum, double maximum)
+        public static double ModuloBetween(double value, double minimum, double maximum)
         {
             if (value.IsValid() && minimum.IsValid() && maximum.IsValid())
             {

--- a/KerbalEngineer/Helpers/AngleHelper.cs
+++ b/KerbalEngineer/Helpers/AngleHelper.cs
@@ -20,51 +20,35 @@ namespace KerbalEngineer.Helpers
 
     public static class AngleHelper
     {
+        /// <summary>
+        ///     Same as ClampBetween(angle, -180, 180).
+        /// </summary>
         public static double Clamp180(double angle)
         {
             if (angle.IsValid())
             {
-                if (angle < -180.0)
-                {
-                    do
-                    {
-                        angle += 360.0;
-                    }
-                    while (angle < -180.0);
-                }
-                else if (angle > 180.0)
-                {
-                    do
-                    {
-                        angle -= 360.0;
-                    }
-                    while (angle > 180.0);
-                }
+                while (angle < -180d)
+                    angle += 360d;
+
+                while (angle >= 180d)
+                    angle -= 360d;
             }
 
             return angle;
         }
 
+        /// <summary>
+        ///     Same as ClampBetween(angle, 0, 360).
+        /// </summary>
         public static double Clamp360(double angle)
         {
             if (angle.IsValid())
             {
-                if (angle < 0.0)
-                {
-                    do
-                    {
-                        angle += 360.0;
-                    }
-                    while (angle < 0.0);
-                }
-                else if (angle >= 360.0)
-                {
-                    do
-                    {
-                        angle -= 360.0;
-                    }
-                    while (angle >= 360.0);
-                }
+                while (angle < 0d)
+                    angle += 360d;
+
+                while (angle >= 360d)
+                    angle -= 360d;
             }
 
             return angle;
@@ -74,15 +58,13 @@ namespace KerbalEngineer.Helpers
         {
             if (value.IsValid() && minimum.IsValid() && maximum.IsValid())
             {
+                double mod = maximum - minimum;
+
                 while (value < minimum)
-                {
-                    value += maximum;
-                }
+                    value += mod;
 
                 while (value > maximum)
-                {
-                    value -= maximum;
-                }
+                    value -= mod;
             }
 
             return value;
@@ -91,13 +73,13 @@ namespace KerbalEngineer.Helpers
         public static double GetAngleBetweenVectors(Vector3d left, Vector3d right)
         {
             double angle = Vector3d.Angle(left, right);
-            Vector3d rotated = QuaternionD.AngleAxis(90.0, Vector3d.forward) * right;
+            Vector3d rotated = QuaternionD.AngleAxis(90, Vector3d.forward) * right;
 
-            if (Vector3d.Angle(rotated, left) > 90.0)
-            {
-                return 360.0 - angle;
-            }
+            if (Vector3d.Angle(rotated, left) > 90)
+                return 360 - angle;
+
             return angle;
         }
+
     }
 }

--- a/KerbalEngineer/Helpers/Averager.cs
+++ b/KerbalEngineer/Helpers/Averager.cs
@@ -26,17 +26,15 @@ namespace KerbalEngineer
         private Vector3d sum = Vector3d.zero;
         private uint count = 0;
 
-        public void Add(Vector3d v) {
+        public void Add(Vector3d v)
+        {
             sum += v;
             count += 1;
         }
 
-        public Vector3d Get() {
-            if (count > 0) {
-                return sum / count;
-            } else {
-                return Vector3d.zero;
-            }
+        public Vector3d GetAverage
+        {
+            get => count > 0 ? sum / count : Vector3d.zero;
         }
 
         public void Reset()
@@ -51,28 +49,27 @@ namespace KerbalEngineer
         private Vector3d sum = Vector3d.zero;
         private double totalweight = 0;
 
-        public void Add(Vector3d v, double weight) {
+        public void Add(Vector3d v, double weight)
+        {
             sum += v * weight;
             totalweight += weight;
         }
 
-        public Vector3d Get() {
-            if (totalweight > 0) {
-                return sum / totalweight;
-            } else {
-                return Vector3d.zero;
-            }
+        public Vector3d GetAverage
+        {
+            get => totalweight > 0 ? sum / totalweight : Vector3d.zero;
         }
 
-        public double GetTotalWeight() {
-            return totalweight;
+        public double GetTotalWeight
+        {
+            get => totalweight;
         }
 
         public void Reset()
         {
             sum = Vector3d.zero;
-            totalweight = 0.0;
+            totalweight = 0;
         }
+
     }
 }
-

--- a/KerbalEngineer/Helpers/ForceAccumulator.cs
+++ b/KerbalEngineer/Helpers/ForceAccumulator.cs
@@ -83,8 +83,9 @@ namespace KerbalEngineer
 			avgApplicationPoint.Add(applicationPoint, force.magnitude);
 		}
 
-        public Vector3d GetAverageForceApplicationPoint() {
-            return avgApplicationPoint.Get();
+        public Vector3d GetAverageForceApplicationPoint()
+        {
+            return avgApplicationPoint.GetAverage;
         }
 
         public void AddForce(AppliedForce force) {
@@ -108,16 +109,16 @@ namespace KerbalEngineer
         public Vector3d GetMinTorqueForceApplicationPoint(Vector3d origin)
         {
             double fmag = totalForce.sqrMagnitude;
-            if (fmag <= 0) {
+
+            if (fmag <= 0)
                 return origin;
-            }
 
             return origin + Vector3d.Cross(totalForce, TorqueAt(origin)) / fmag;
         }
 
         public Vector3d GetMinTorqueForceApplicationPoint()
         {
-            return GetMinTorqueForceApplicationPoint(avgApplicationPoint.Get());
+            return GetMinTorqueForceApplicationPoint(avgApplicationPoint.GetAverage);
         }
 
 	    public void Reset()

--- a/KerbalEngineer/Helpers/ForceAccumulator.cs
+++ b/KerbalEngineer/Helpers/ForceAccumulator.cs
@@ -26,17 +26,10 @@ namespace KerbalEngineer
     // a (force, application point) tuple
     public class AppliedForce
     {
-        private static readonly Pool<AppliedForce> pool = new Pool<AppliedForce>(Create, Reset);
+        private static readonly Pool<AppliedForce> pool = new Pool<AppliedForce>(() => new AppliedForce(), null);
 
         public Vector3d vector;
         public Vector3d applicationPoint;
-
-        static private AppliedForce Create()
-        {
-            return new AppliedForce();
-        }
-
-        static private void Reset(AppliedForce appliedForce) { }
 
         static public AppliedForce New(Vector3d vector, Vector3d applicationPoint)
         {
@@ -50,7 +43,6 @@ namespace KerbalEngineer
         {
             pool.Release(this);
         }
-
 
     }
 
@@ -71,7 +63,6 @@ namespace KerbalEngineer
 		private Vector3d totalForce = Vector3d.zero;
 		// Torque needed to compensate if force were applied at origin.
 		private Vector3d totalZeroOriginTorque = Vector3d.zero;
-
 		// Weighted average of force application points.
 		private WeightedVectorAverager avgApplicationPoint = new WeightedVectorAverager();
 
@@ -88,7 +79,8 @@ namespace KerbalEngineer
             return avgApplicationPoint.GetAverage;
         }
 
-        public void AddForce(AppliedForce force) {
+        public void AddForce(AppliedForce force)
+        {
             AddForce(force.applicationPoint, force.vector);
         }
 
@@ -127,5 +119,6 @@ namespace KerbalEngineer
 	        totalZeroOriginTorque = Vector3d.zero;
             avgApplicationPoint.Reset();
 	    }
+        
 	}
 }

--- a/KerbalEngineer/Helpers/Pool.cs
+++ b/KerbalEngineer/Helpers/Pool.cs
@@ -3,51 +3,69 @@ using System.Collections.Generic;
 namespace KerbalEngineer
 {
     /// <summary>
-    ///     Pool of object
+    ///     Pool of objects, each object gets reset (by delegate) before being reused.
+    ///     THREAD SAFE.
     /// </summary>
-    public class Pool<T> {
-        
+    public class Pool<T>
+    {
         private readonly Stack<T> values = new Stack<T>();
 
-        private readonly CreateDelegate<T> create;
-        private readonly ResetDelegate<T> reset;
+        private readonly CreateDelegate create;
+        private readonly ResetDelegate reset;
 
-        public delegate R CreateDelegate<out R>();
-        public delegate void ResetDelegate<in T1>(T1 a);
+        public delegate T CreateDelegate();
+        public delegate void ResetDelegate(T value);
         
         /// <summary>
         ///     Creates an empty pool with the specified object creation and reset delegates.
+        ///     Reset function can be null, so no action is performed on an object.
         /// </summary>
-        public Pool(CreateDelegate<T> create, ResetDelegate<T> reset) {
+        public Pool(CreateDelegate create, ResetDelegate reset = null)
+        {
             this.create = create;
-            this.reset = reset;
+            this.reset = reset ?? (x => {});
         }
 
         /// <summary>
         ///     Borrows an object from the pool.
         /// </summary>
-        public T Borrow() {
-            lock (values) {
-                return values.Count > 0 ? values.Pop() : create();
+        public T Borrow()
+        {
+            lock (values)
+            {
+                if (values.Count > 0) 
+                    return values.Pop();
             }
+            T value = create();
+            reset(value);
+            return value;
         }
         
         /// <summary>
-        ///     Release an object, reset it and returns it to the pool.
+        ///     Release an object, reset it and return it to the pool.
         /// </summary>
-        public void Release(T value) {
+        public void Release(T value)
+        {
             reset(value);
-            lock (values) {
+            lock (values)
+            {
                 values.Push(value);
             }
         }
         
         /// <summary>
-        ///     Current size of the pool.
+        ///     Number of objects currently available for use.
         /// </summary>
-        public int Count()
+        public int Count
         {
-            return values.Count;
+            get
+            {
+                lock (values)
+                {
+                    return values.Count;
+                }
+            }
         }
+        
     }
 }

--- a/KerbalEngineer/Helpers/TimeFormatter.cs
+++ b/KerbalEngineer/Helpers/TimeFormatter.cs
@@ -21,40 +21,32 @@ namespace KerbalEngineer.Helpers
     {
         public static string ConvertToString(double seconds, string format = "F1")
         {
-            int years = 0;
-            int days = 0;
-            int hours = 0;
-            int minutes = 0;
+            if (seconds == 0)
+                return string.Format("{0}s", seconds.ToString(format));
 
-            if (seconds > 0.0)
-            {
-                years = (int)(seconds / KSPUtil.dateTimeFormatter.Year);
-                seconds -= years * KSPUtil.dateTimeFormatter.Year;
-
-                days = (int)(seconds / KSPUtil.dateTimeFormatter.Day);
-                seconds -= days * KSPUtil.dateTimeFormatter.Day;
-
-                hours = (int)(seconds / 3600.0);
-                seconds -= hours * 3600.0;
-
-                minutes = (int)(seconds / 60.0);
-                seconds -= minutes * 60.0;
-            }
+            int years = (int)(seconds / KSPUtil.dateTimeFormatter.Year);
+            seconds -= years * KSPUtil.dateTimeFormatter.Year;
+            int days = (int)(seconds / KSPUtil.dateTimeFormatter.Day);
+            seconds -= days * KSPUtil.dateTimeFormatter.Day;
+            int hours = (int)(seconds / 3600d);
+            seconds -= hours * 3600;
+            int minutes = (int)(seconds / 60d);
+            seconds -= minutes * 60;
 
             if (years > 0)
-            {
                 return string.Format("{0}y {1}d {2}h {3}m {4}s", years, days, hours, minutes, seconds.ToString(format));
-            }
-            if (days > 0)
-            {
-                return string.Format("{0}d {1}h {2}m {3}s", days, hours, minutes, seconds.ToString(format));
-            }
-            if (hours > 0)
-            {
-                return string.Format("{0}h {1}m {2}s", hours, minutes, seconds.ToString(format));
-            }
 
-            return minutes > 0 ? string.Format("{0}m {1}s", minutes, seconds.ToString(format)) : string.Format("{0}s", seconds.ToString(format));
+            if (days > 0)
+                return string.Format("{0}d {1}h {2}m {3}s", days, hours, minutes, seconds.ToString(format));
+
+            if (hours > 0)
+                return string.Format("{0}h {1}m {2}s", hours, minutes, seconds.ToString(format));
+
+            if (minutes > 0)
+                return string.Format("{0}m {1}s", minutes, seconds.ToString(format));
+
+            return string.Format("{0}s", seconds.ToString(format));
         }
+        
     }
 }

--- a/KerbalEngineer/Helpers/Units.cs
+++ b/KerbalEngineer/Helpers/Units.cs
@@ -24,8 +24,8 @@ namespace KerbalEngineer.Helpers
     public static class Units
     {
         public const double GRAVITY = 9.80665;
-        public const double RAD_TO_DEG = 180.0 / Math.PI;
-        public const double DEG_TO_RAD = Math.PI / 180.0;
+        public const double RAD_TO_DEG = 180 / Math.PI;
+        public const double DEG_TO_RAD = Math.PI / 180;
 
         public static string Concat(int value1, int value2)
         {
@@ -34,55 +34,64 @@ namespace KerbalEngineer.Helpers
 
         public static string ConcatF(double value1, double value2, int decimals = 1)
         {
-            return value1.ToString("F" + decimals) + " / " + value2.ToString("F" + decimals);
+            string f = "F" + decimals;
+            return value1.ToString(f) + " / " + value2.ToString(f);
         }
 
         public static string ConcatF(double value1, double value2, double value3, int decimals = 1)
         {
-            return value1.ToString("F" + decimals) + " / " + value2.ToString("F" + decimals) + " / " + value3.ToString("F" + decimals);
+            string f = "F" + decimals;
+            return value1.ToString(f) + " / " + value2.ToString(f) + " / " + value3.ToString(f);
         }
 
         public static string ConcatN(double value1, double value2, int decimals = 1)
         {
-            return value1.ToString("N" + decimals) + " / " + value2.ToString("N" + decimals);
+            string f = "N" + decimals;
+            return value1.ToString(f) + " / " + value2.ToString(f);
         }
 
         public static string ConcatN(double value1, double value2, double value3, int decimals = 1)
         {
-            return value1.ToString("N" + decimals) + " / " + value2.ToString("N" + decimals) + " / " + value3.ToString("N" + decimals);
+            string f = "N" + decimals;
+            return value1.ToString(f) + " / " + value2.ToString(f) + " / " + value3.ToString(f);
         }
 
         public static string Cost(double value, int decimals = 1)
         {
-            if (value >= 1000000.0)
-            {
-                return (value / 1000.0).ToString("N" + decimals) + "K";
-            }
-            return value.ToString("N" + decimals);
+            string f = "N" + decimals;
+
+            if (value >= 1000000)
+                return (value / 1000).ToString(f) + "K";
+
+            return value.ToString(f);
         }
 
         public static string Cost(double value1, double value2, int decimals = 1)
         {
-            if (value1 >= 1000000.0 || value2 >= 1000000.0)
-            {
-                return (value1 / 1000.0).ToString("N" + decimals) + " / " + (value2 / 1000.0).ToString("N" + decimals) + "K";
-            }
-            return value1.ToString("N" + decimals) + " / " + value2.ToString("N" + decimals);
+            string f = "N" + decimals;
+
+            if (value1 >= 1000000 || value2 >= 1000000)
+                return (value1 / 1000).ToString(f) + " / " + (value2 / 1000).ToString(f) + "K";
+
+            return value1.ToString(f) + " / " + value2.ToString(f);
         }
 
         public static string ToAcceleration(double value, int decimals = 2)
         {
-            return value.ToString("N" + decimals) + "m/s²";
+            string f = "N" + decimals;
+            return value.ToString(f) + "m/s²";
         }
 
         public static string ToAcceleration(double value1, double value2, int decimals = 2)
         {
-            return value1.ToString("N" + decimals) + " / " + value2.ToString("N" + decimals) + "m/s²";
+            string f = "N" + decimals;
+            return value1.ToString(f) + " / " + value2.ToString(f) + "m/s²";
         }
 
         public static string ToAngle(double value, int decimals = 5)
         {
-            return value.ToString("F" + decimals) + "°";
+            string f = "F" + decimals;
+            return value.ToString(f) + "°";
         }
 
         public static string ToAngleDMS(double value)
@@ -91,38 +100,33 @@ namespace KerbalEngineer.Helpers
             int deg = (int)Math.Floor(absAngle);
             double rem = absAngle - deg;
             int min = (int)Math.Floor(rem * 60);
-            rem -= ((double)min / 60);
+            rem -= ((double)min / 60d);
             int sec = (int)Math.Floor(rem * 3600);
             return string.Format("{0:0}° {1:00}' {2:00}\"", deg, min, sec);
         }
 
         public static string ToDistance(double value, int decimals = 1)
         {
-            if (Math.Abs(value) < 1000000.0)
+            string f = "N" + decimals;
+            if (Math.Abs(value) < 1000000)
             {
-                if (Math.Abs(value) >= 10.0)
-                {
-                    return value.ToString("N" + decimals) + "m";
-                }
+                if (Math.Abs(value) >= 10)
+                    return value.ToString(f) + "m";
 
-                value *= 100.0;
-                if (Math.Abs(value) >= 100.0)
-                {
-                    return value.ToString("N" + decimals) + "cm";
-                }
+                value *= 100;
+                if (Math.Abs(value) >= 100)
+                    return value.ToString(f) + "cm";
 
-                value *= 10.0;
-                return value.ToString("N" + decimals) + "mm";
+                value *= 10;
+                return value.ToString(f) + "mm";
             }
 
-            value /= 1000.0;
-            if (Math.Abs(value) < 1000000.0)
-            {
-                return value.ToString("N" + decimals) + "km";
-            }
+            value /= 1000;
+            if (Math.Abs(value) < 1000000)
+                return value.ToString(f) + "km";
 
-            value /= 1000.0;
-            return value.ToString("N" + decimals) + "Mm";
+            value /= 1000;
+            return value.ToString(f) + "Mm";
         }
 
         public static string ToFlux(double value)
@@ -132,13 +136,13 @@ namespace KerbalEngineer.Helpers
 
         public static string ToForce(double value)
         {
-            return value.ToString((value < 100000.0) ? (value < 10000.0) ? (value < 100.0) ? (Math.Abs(value) < double.Epsilon) ? "N0" : "N3" : "N2" : "N1" : "N0") + "kN";
+            return value.ToString((value < 100000) ? (value < 10000) ? (value < 100) ? (Math.Abs(value) < double.Epsilon) ? "N0" : "N3" : "N2" : "N1" : "N0") + "kN";
         }
 
         public static string ToForce(double value1, double value2)
         {
-            string format1 = (value1 < 100000.0) ? (value1 < 10000.0) ? (value1 < 100.0) ? (Math.Abs(value1) < double.Epsilon) ? "N0" : "N3" : "N2" : "N1" : "N0";
-            string format2 = (value2 < 100000.0) ? (value2 < 10000.0) ? (value2 < 100.0) ? (Math.Abs(value2) < double.Epsilon) ? "N0" : "N3" : "N2" : "N1" : "N0";
+            string format1 = (value1 < 100000) ? (value1 < 10000) ? (value1 < 100) ? (Math.Abs(value1) < double.Epsilon) ? "N0" : "N3" : "N2" : "N1" : "N0";
+            string format2 = (value2 < 100000) ? (value2 < 10000) ? (value2 < 100) ? (Math.Abs(value2) < double.Epsilon) ? "N0" : "N3" : "N2" : "N1" : "N0";
             return value1.ToString(format1) + " / " + value2.ToString(format2) + "kN";
         }
 
@@ -149,50 +153,52 @@ namespace KerbalEngineer.Helpers
 
         public static string ToMass(double value, int decimals = 0)
         {
-            if (value >= 1000.0)
-            {
-                return value.ToString("N" + decimals + 2) + "t";
-            }
+            string f = "N" + decimals;
+            string f2 = "N" + decimals + 2;
 
-            value *= 1000.0;
-            return value.ToString("N" + decimals) + "kg";
+            if (value >= 1000)
+                return value.ToString(f2) + "t";
+
+            return (value * 1000).ToString(f) + "kg";
         }
 
         public static string ToMass(double value1, double value2, int decimals = 0)
         {
-            if (value1 >= 1000.0f || value2 >= 1000.0f)
+            if (value1 >= 1000 || value2 >= 1000)
             {
-                return value1.ToString("N" + decimals + 2) + " / " + value2.ToString("N" + decimals + 2) + "t";
+                string f2 = "N" + decimals + 2;
+                return value1.ToString(f2) + " / " + value2.ToString(f2) + "t";
             }
 
-            value1 *= 1000.0;
-            value2 *= 1000.0;
-            return value1.ToString("N" + decimals) + " / " + value2.ToString("N" + decimals) + "kg";
+            string f = "N" + decimals;
+            return (value1 * 1000).ToString(f) + " / " + (value2 * 1000).ToString(f) + "kg";
         }
 
         public static string ToPercent(double value, int decimals = 2)
         {
-            value *= 100.0;
-            return value.ToString("F" + decimals) + "%";
+            string f = "F" + decimals;
+            return (value * 100).ToString(f) + "%";
         }
 
         public static string ToPressure(double value)
         {
-            return value.ToString((value < 100000.0) ? (value < 10000.0) ? (value < 100.0) ? (Math.Abs(value) < double.Epsilon) ? "N0" : "N3" : "N2" : "N1" : "N0") + "kN/m²";
+            return value.ToString((value < 100000) ? (value < 10000) ? (value < 100) ? (Math.Abs(value) < double.Epsilon) ? "N0" : "N3" : "N2" : "N1" : "N0") + "kN/m²";
         }
 
         public static string ToRate(double value, int decimals = 1)
         {
-            return value < 1.0 ? (value * 60.0).ToString("F" + decimals) + "/min" : value.ToString("F" + decimals) + "/sec";
+            string f = "F" + decimals;
+            return value < 1 ? (value * 60).ToString(f) + "/min" : value.ToString(f) + "/sec";
         }
 
         public static string ToSpeed(double value, int decimals = 2)
         {
-            if (Math.Abs(value) < 1.0)
-            {
-                return (value * 1000.0).ToString("N" + decimals) + "mm/s";
-            }
-            return value.ToString("N" + decimals) + "m/s";
+            string f = "N" + decimals;
+
+            if (Math.Abs(value) < 1)
+                return (value * 1000).ToString(f) + "mm/s";
+
+            return value.ToString(f) + "m/s";
         }
 
         public static string ToTemperature(double value)
@@ -212,7 +218,7 @@ namespace KerbalEngineer.Helpers
 
         public static string ToTorque(double value)
         {
-            return value.ToString((value < 100.0) ? (Math.Abs(value) < double.Epsilon) ? "N0" : "N2" : "N0") + "kNm";
+            return value.ToString((value < 100) ? (Math.Abs(value) < double.Epsilon) ? "N0" : "N2" : "N0") + "kNm";
         }
     }
 }

--- a/KerbalEngineer/Helpers/XmlHelper.cs
+++ b/KerbalEngineer/Helpers/XmlHelper.cs
@@ -12,15 +12,13 @@
         /// </summary>
         public static T LoadObject<T>(string path)
         {
-            T obj = default(T);
-
             if (File.Exists(path))
             {
                 try
                 {
                     using (StreamReader stream = new StreamReader(path, Encoding.UTF8))
                     {
-                        obj = (T)new XmlSerializer(typeof(T)).Deserialize(stream);
+                        return (T)new XmlSerializer(typeof(T)).Deserialize(stream);
                     }
                 }
                 catch (Exception ex)
@@ -29,7 +27,7 @@
                 }
             }
 
-            return obj;
+            return default(T);
         }
 
         /// <summary>
@@ -47,9 +45,7 @@
         public static void SaveObject<T>(string path, T obj)
         {
             if (obj == null || string.IsNullOrEmpty(path))
-            {
                 return;
-            }
 
             try
             {
@@ -63,5 +59,6 @@
                 MyLogger.Exception(ex);
             }
         }
+        
     }
 }

--- a/KerbalEngineer/VesselSimulator/Simulation.cs
+++ b/KerbalEngineer/VesselSimulator/Simulation.cs
@@ -122,7 +122,7 @@ namespace KerbalEngineer.VesselSimulator
                     vectorAverager.Add(partSim.centerOfMass, partSim.GetMass(currentStage, true));
                 }
 
-                return vectorAverager.Get();
+                return vectorAverager.GetAverage;
             }
         }
 


### PR DESCRIPTION
 **Please review one commit at a time, it will make reading much easier.**  

Obvious part: I cleaned up classes according to these guidelines (better readability and same or better performance). No semantics have changed, you can take my word and just accept these.

- foreach over for loops
- LINQ oneliners over elaborate loops
- 0 over 0d 0f 0.0 literals
- easy on curly braces
- computable properties over parameterless methods

Important part: Requires your insight. 

- Pool now resets after creating an item, reset delegate not required anymore, count threading bugfix
- Units methods computed "N"+decimals several times, increasing GC thrashing
- AngleHelper.ClampBetween changed semantics
It used to behave like clamp but I think modulo semantics were intended, it worked the same if min=0 but differrs eg. min=-180 max=+180. 
- AngleHelper.Clamp renamed to Modulo
This seems to be common terminology on internet: clamp is min/max, while this method implements modulo semantics. Note that other clamping methods in this project do respect this terminology. 
