### PR TITLE
Added display for total dV of whole planned trip

### DIFF
--- a/KerbalEngineer/Flight/Readouts/Orbital/ManoeuvreNode/ManoeuvreProcessor.cs
+++ b/KerbalEngineer/Flight/Readouts/Orbital/ManoeuvreNode/ManoeuvreProcessor.cs
@@ -20,6 +20,7 @@
 #region Using Directives
 
 using System;
+using System.Linq;
 
 using KerbalEngineer.Extensions;
 using KerbalEngineer.Flight.Readouts.Vessel;
@@ -74,6 +75,8 @@ namespace KerbalEngineer.Flight.Readouts.Orbital.ManoeuvreNode
         public static double ProgradeDeltaV { get; private set; }
 
         public static double RadialDeltaV { get; private set; }
+
+        public static double TripDeltaV { get; private set; }
 
         public static bool ShowDetails { get; set; }
 
@@ -134,6 +137,12 @@ namespace KerbalEngineer.Flight.Readouts.Orbital.ManoeuvreNode
 
             BurnTime = burnTime;
             HalfBurnTime = midPointTime;
+
+            var tripDeltaV = TotalDeltaV;
+            foreach (var n in FlightGlobals.ActiveVessel.patchedConicSolver.maneuverNodes.Skip(1) ) {
+                tripDeltaV += n.DeltaV.magnitude;
+            }
+            TripDeltaV = tripDeltaV;
 
             ShowDetails = true;
         }

--- a/KerbalEngineer/Flight/Readouts/ReadoutLibrary.cs
+++ b/KerbalEngineer/Flight/Readouts/ReadoutLibrary.cs
@@ -96,6 +96,7 @@ namespace KerbalEngineer.Flight.Readouts
                 readouts.Add(new SpeedAtApoapsis());
                 readouts.Add(new SpeedAtPeriapsis());
                 readouts.Add(new TimeToAtmosphere());
+                readouts.Add(new TripTotalDeltaV());
 
                 // Surface
                 readouts.Add(new AltitudeSeaLevel());

--- a/KerbalEngineer/KerbalEngineer.csproj
+++ b/KerbalEngineer/KerbalEngineer.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Flight\Readouts\Orbital\ManoeuvreNode\PostBurnInclination.cs" />
     <Compile Include="Flight\Readouts\Orbital\ManoeuvreNode\PostBurnPeriapsis.cs" />
     <Compile Include="Flight\Readouts\Orbital\ManoeuvreNode\PostBurnPeriod.cs" />
+    <Compile Include="Flight\Readouts\Orbital\ManoeuvreNode\TripTotalDeltaV.cs" />
     <Compile Include="Flight\Readouts\Orbital\MeanAnomalyAtEpoc.cs" />
     <Compile Include="Flight\Readouts\Orbital\MeanAnomaly.cs" />
     <Compile Include="Flight\Readouts\Orbital\EccentricAnomaly.cs" />


### PR DESCRIPTION
I added a display, showing total deltaV needed to achieve whole pre-planned set of maneuver nodes.

This is helpful for planning ahead whether the trip is doable with propellants available in vessel.